### PR TITLE
fix(PopApiScraper): Fix issue where status files are empty

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,7 @@ export default {
   input: './src/index.js',
   external: [
     ...Object.keys(dependencies),
+    'cluster',
     'fs',
     'path',
     'querystring',

--- a/src/PopApiScraper.js
+++ b/src/PopApiScraper.js
@@ -2,6 +2,7 @@
 // @flow
 import fs from 'fs-extra'
 import pMap from 'p-map'
+import { isMaster } from 'cluster'
 
 import Context from './Context'
 
@@ -75,8 +76,10 @@ export default class PopApiScraper {
      */
     this.updatedPath = updatedPath
 
-    fs.createWriteStream(this.statusPath).end()
-    fs.createWriteStream(this.updatedPath).end()
+    if (isMaster) {
+      fs.createWriteStream(this.statusPath).end()
+      fs.createWriteStream(this.updatedPath).end()
+    }
 
     PopApi.scraper = this
   }

--- a/test/PopApiScraper.spec.js
+++ b/test/PopApiScraper.spec.js
@@ -1,8 +1,10 @@
 // Import the necessary modules.
 // @flow
 /* eslint-disable no-unused-expressions */
+import cluster from 'cluster'
 import del from 'del'
 import mkdirp from 'mkdirp'
+import sinon from 'sinon'
 import { expect } from 'chai'
 import { join } from 'path'
 import { PopApi } from 'pop-api'
@@ -57,6 +59,25 @@ describe('PopApiScraper', () => {
     expect(popApiScraper.statusPath).to.be.a('string')
     expect(popApiScraper.updatedPath).to.exist
     expect(popApiScraper.updatedPath).to.be.a('string')
+  })
+
+  /** @test {PopApiScraper#constructor} */
+  it('should only create teh status files on the master node', () => {
+    const stub = sinon.stub(cluster, 'isMaster')
+    stub.value(false)
+
+    new PopApiScraper(PopApi, { // eslint-disable-line no-new
+      statusPath: join(...[
+        tempDir,
+        'status.json'
+      ]),
+      updatedPath: join(...[
+        tempDir,
+        'updated.json'
+      ])
+    })
+
+    stub.restore()
   })
 
   /** @test {PopApiScraper#constructor} */


### PR DESCRIPTION
Fixes #4

## Proposed Changes

  - Only touch the `status` and `updated` files when node is in master

